### PR TITLE
fix: Add marker labels and circles to map in opposite orders.

### DIFF
--- a/lib/builders/Map-base.js
+++ b/lib/builders/Map-base.js
@@ -25,8 +25,14 @@ function MapBuilder (definition, options) {
       : null
 
     for (const [idx, m] of markers.entries()) {
-      addMarker(m.format, idx, m, markerDetails, map, builder, definition)
+      addLabel(m.format, idx, m, markerDetails, map, builder, definition)
     } // for ...
+
+    // add circles in reverse order, so bottom most label is bottom most circle
+    markers.reverse()
+    for (const [, m] of markers.entries()) {
+      addCircle(m.format, m, map)
+    }
   } // if ...
 
   addMarkerPath(map, definition)
@@ -42,7 +48,7 @@ function findMarkers (definition) {
   return markers
 } // findMarkers
 
-function addMarker (format, idx, m, markerDetails, map, builder, definition) {
+function addLabel (format, idx, m, markerDetails, map, builder, definition) {
   format = cleanFormat(format)
 
   if (markerDetails) {
@@ -58,9 +64,13 @@ function addMarker (format, idx, m, markerDetails, map, builder, definition) {
       markerEditButton(idx, m, item, map, builder, format)
     }
   }
+} // addLabel
+
+function addCircle (format, m, map) {
+  format = cleanFormat(format)
 
   mapCircle(map, m, format)
-} // addMarker
+}
 
 function cleanFormat (f) {
   if (['LatLon', 'OSGridRef'].includes(f)) return f


### PR DESCRIPTION
I want the first labelled point to be the topmost marker on the map. Map markers are drawn in the
order they're added, consequently the first marker added is the lowest one and the last marker the
topmost. This feels kind of counterintuitive, so I've switched things around to add the labels, then
added the markers in the reverse order.

Here's an example from the data-management-blueprint that motivated the change
![Screenshot from 2020-10-27 14-35-50](https://user-images.githubusercontent.com/555337/97317169-6f69d300-1862-11eb-8cea-30a06fbda112.png)

I want the conflicting location to be listed after the location, but without this change the yellow conflict marker might sit *on top of* the blue location marker. As a result, I wouldn't be able to click and drag the blue location which kind of defeats the whole object of the map. 